### PR TITLE
Add the default root page route

### DIFF
--- a/test/controllers/todos_controller_test.rb
+++ b/test/controllers/todos_controller_test.rb
@@ -6,7 +6,7 @@ class TodosControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get index" do
-    get todos_url
+    get root_url
     assert_response :success
   end
 
@@ -43,6 +43,6 @@ class TodosControllerTest < ActionDispatch::IntegrationTest
       delete todo_url(@todo)
     end
 
-    assert_redirected_to todos_url
+    assert_redirected_to root_url
   end
 end

--- a/test/system/todos_test.rb
+++ b/test/system/todos_test.rb
@@ -6,12 +6,12 @@ class TodosTest < ApplicationSystemTestCase
   end
 
   test "visiting the index" do
-    visit todos_url
+    visit root_url
     assert_selector "h1", text: "Todos"
   end
 
   test "creating a Todo" do
-    visit todos_url
+    visit root_url
     click_on "New Todo"
 
     check "Completed" if @todo.completed
@@ -23,7 +23,7 @@ class TodosTest < ApplicationSystemTestCase
   end
 
   test "updating a Todo" do
-    visit todos_url
+    visit root_url
     click_on "Edit", match: :first
 
     check "Completed" if @todo.completed
@@ -35,7 +35,7 @@ class TodosTest < ApplicationSystemTestCase
   end
 
   test "destroying a Todo" do
-    visit todos_url
+    visit root_url
     page.accept_confirm do
       click_on "Destroy", match: :first
     end


### PR DESCRIPTION
By default the Rails root page is the "Yay! You’re on Rails!" welcome page.

This patch defines the `root` route that points to `todos#index` and removes
the `index` action from the `resources :todos` routes, as we should only have
one unique route for each controller action.

More info about using `root`:
https://guides.rubyonrails.org/routing.html#using-root

All the `todos` routes can be listed with the following command:
``` sh
bin/rails routes | grep todos
```