### PR TITLE
Add "Clear Completed" button in footer

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -61,9 +61,11 @@ class TodosController < ApplicationController
   # DELETE /todos/clear_completed
   # DELETE /todos/clear_completed.json
   def clear_completed
-    # - Clear all completed todos
-    # - Redirect back to root_url
-    # - Support JSON
+    Todo.where(completed: true).delete_all
+    respond_to do |format|
+      format.html { redirect_back fallback_location: root_url, notice: 'Completed Todos were successfully destroyed.' }
+      format.json { head :no_content }
+    end
   end
 
   private

--- a/test/system/todos_test.rb
+++ b/test/system/todos_test.rb
@@ -126,8 +126,8 @@ class TodosTest < ApplicationSystemTestCase
     assert_no_selector 'label', text: 'Install Ruby'
     assert_no_selector 'button.clear-completed', text: 'Clear completed'
     assert_equal [
-      'Learn Stimulus JS',
-      'Learn Rails'
+      'Learn Rails',
+      'Learn Stimulus JS'
     ], todos_title
   end
 end


### PR DESCRIPTION
This patch adds the "Clear Completed" button in the footer, as specified the button
is only shown when at least one completed todo is present. Like the destroy todo
button, a`button_to` ActionView helper is used. A custom collection route on the
`todos` resource to handle the `clear_completed` action.

todoapp specification:
- https://github.com/tastejs/todomvc/blob/master/app-spec.md#clear-completed-button

Documentation:
- https://guides.rubyonrails.org/routing.html#adding-collection-routes
- https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-delete_all
- https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-destroy_all
- https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-button_to