### PR TITLE
Exercice-14 

### DIFF
--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -33,7 +33,7 @@
           class: 'edit',
           data: {
             target: 'editable.input',
-            action: 'blur->editable#submitForm'
+            action: 'blur->editable#submitForm keydown->editable#escapeInput'
           },
           id: nil
         %>


### PR DESCRIPTION
This patch ensures that any title changes are discarded when the escape key is
pressed, as specificed, the edit state is also left.

Which key has been pressed down on the `keydown` event can be checked with:
``` js
event.key === 'Escape'
```

todoapp specification:
- https://github.com/tastejs/todomvc/blob/master/app-spec.md#editing

Documentation:
- https://stimulusjs.org/handbook
- https://stimulusjs.org/reference
- https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event
- https://www.w3.org/TR/uievents-key/#control
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/blur